### PR TITLE
Removed extraneous tags in 2 steps (commits)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -205,7 +205,6 @@ epub_exclude_files = ['search.html']
 
 # # -- Hieroglyph Slide Configuration ------------
 # #  Do we need this anymore??
-# #    Not really -- but we'd need to clean out all the "nextslide", etc directives...
 
 extensions += [
     'hieroglyph',

--- a/source/exercises/args_kwargs_lab.rst
+++ b/source/exercises/args_kwargs_lab.rst
@@ -61,7 +61,6 @@ we are telling you it should do.
 
     - ``func(*regular, *links)``
 
-.. nextslide::
 
 **Generic parameters:**
 

--- a/source/exercises/html_renderer.rst
+++ b/source/exercises/html_renderer.rst
@@ -320,7 +320,6 @@ So:
 Notes on handling "duck typing"
 ===============================
 
-.. rst-class:: left
 
   In this exercise, we need to deal with the fact that XML (and thus HTML) allows *either* plain text *or* other tags to be the content of a tag. Our code also needs to handle the fact that there are two possible types that we need to be able to render.
 
@@ -475,11 +474,9 @@ If you have a unit test that calls every render method in your code -- then it s
 HTML Primer
 ============
 
-.. rst-class:: medium
 
     The very least you need to know about html to do this assignment.
 
-.. rst-class:: left
 
   If you are familiar with html, then this will all make sense to you. If you have never seen html before, this might be a bit intimidating, but you really don't need to know much to do this assignment.
 

--- a/source/exercises/html_renderer.rst
+++ b/source/exercises/html_renderer.rst
@@ -173,7 +173,6 @@ You can now render some ``<p>`` tags (and others) with attributes.
 
 See: :download:`test_html_output4.htm  <../examples/html_render/test_html_output4.html>`
 
-.. nextslide:: the "class" attribute.
 
 NOTE: if you do "proper" CSS+html, then you wouldn't specify style directly in element attributes.
 
@@ -350,7 +349,6 @@ You can handle it ahead of time by creating a simple object that wraps a string 
           file_out.write(current_ind)
           file_out.write(self.text)
 
-.. nextslide::
 
 You could require your users to use the wrapper, so instead of just appending a string, they would do:
 
@@ -387,7 +385,6 @@ You could check and see if the object being appended is an Element:
 
 This would work well, but closes the door to using any other type that may not be a strict subclass of Element, but can render itself. Not too bad in this case, but in general, frowned upon in Python.
 
-.. nextslide::
 
 Alternatively, you could check for the string type:
 
@@ -444,7 +441,6 @@ If content is a simple string then it won't have a render method, and an ``Attri
 
 You can catch that, and simply write the content directly instead.
 
-.. nextslide::
 
 You may want to turn it into a string, first::
 

--- a/source/exercises/kata_fourteen.rst
+++ b/source/exercises/kata_fourteen.rst
@@ -44,7 +44,6 @@ came up with:
     shooting upward again and just before the raid wouldn’t have been
     instrumental in capturing the scoundrels right out of jail."
 
-.. nextslide::
 
 Stylistically, it’s Victor Appleton meets Dylan Thomas. Technically,
 it’s all done with trigrams.
@@ -64,7 +63,6 @@ You might generate::
     "may I"  => ["wish"]
     "I may"  => ["I"]
 
-.. nextslide::
 
 This says that the words "I wish" are twice followed by the word
 "I", the words "wish I" are followed once by
@@ -86,7 +84,6 @@ is constrained to another "I".::
 
    I may I wish I
 
-.. nextslide::
 
 Now we look up "wish I", and find we have a choice. Let’s
 choose "may"::
@@ -102,7 +99,6 @@ get::
 At this point we stop, as no sequence starts "I might."
 
 
-.. nextslide::
 
 Given a short input text, the algorithm isn’t too interesting. Feed
 it a book, however, and you give it more options, so the resulting output
@@ -116,7 +112,6 @@ books (Tom Swift and His Airship is `here <http://sailor.gutenberg.org/etext02/0
 Be warned that these files have DOS line endings (carriage return followed by
 newline).
 
-.. nextslide::
 
 
 There is a copy of Sherlock Holmes right here:

--- a/source/exercises/lambda_magic.rst
+++ b/source/exercises/lambda_magic.rst
@@ -53,7 +53,6 @@ Example calling code
     ### If you loop through them all, and call them, each one adds one more
     to the input, 5... i.e. the nth function in the list adds n to the input.
 
-.. nextslide::
 
 See the test code in Examples/Session09
 

--- a/source/exercises/lambda_magic.rst
+++ b/source/exercises/lambda_magic.rst
@@ -7,7 +7,6 @@ lambda and keyword Magic
 Goals
 =====
 
-.. rst-class:: left
 
     * A bit of lambda
     * functions as objects

--- a/source/exercises/sparse_array.rst
+++ b/source/exercises/sparse_array.rst
@@ -7,7 +7,6 @@ Sparse Array Exercise
 Sparse Array
 ============
 
-.. rst-class:: medium
 
     Goal:
 

--- a/source/exercises/sparse_array.rst
+++ b/source/exercises/sparse_array.rst
@@ -50,7 +50,6 @@ Some ideas of how to do that:
 
   This will give its "virtual" length --  with the zeros
 
-.. nextslide::
 
 * It should support getting and setting particular elements via indexing:
 
@@ -70,7 +69,6 @@ Some ideas of how to do that:
 
 * it should have an append() method.
 
-.. nextslide::
 
 * Can you make it support slicing?
 

--- a/source/exercises/trapezoid.rst
+++ b/source/exercises/trapezoid.rst
@@ -77,7 +77,6 @@ Your function definition should look like:
       """
       pass
 
-.. nextslide::
 
 In the function, you want to compute the following equation:
 
@@ -95,7 +94,6 @@ So you will need to:
 
  - multiply by the half of the difference between a and b divided by the number of steps.
 
-.. nextslide::
 
 Note that the first and last values are not doubled, so it may be more efficient to rearrange it like this:
 
@@ -107,7 +105,6 @@ Can you use comprehensions for this?
 
 NOTE: ``range()`` only works for integers -- how can you deal with that?
 
-.. nextslide::
 
 Once you have that, it should work for any function that can be evaluated between a and b.
 
@@ -122,7 +119,6 @@ A few examples of analytical solutions you can use for tests:
 
 A simple horizontal line -- see above.
 
-.. nextslide::
 
 A sloped straight line:
 
@@ -182,7 +178,6 @@ You could write a specialized version of this function for each A, B, and C:
 
 But then you need to write a new function for any value of these parameters you might need.
 
-.. nextslide::
 
 Instead, you can pass in A, B and C each time:
 
@@ -221,7 +216,6 @@ or
     coef = {'A':1, 'B':3, 'C': 2}
     trapz(quadratic, 2, 20, **coef)
 
-.. nextslide::
 
 **NOTE:** Make sure this will work with ANY function, with **ANY** additional positional or keyword arguments -- not just this particular function.
 
@@ -229,7 +223,6 @@ This is pretty conceptually challenging -- but it's very little code!
 
 If you are totally lost -- look at the lecture notes from previous classes -- how can you both accept and pass arbitrary arguments to/from a function?
 
-.. nextslide::
 
 You want your trapz function to take ANY function that can take ANY arbitrary extra arguments -- not just the quadratic function, and not just ``A,B, and C``. So good to test with another example.
 

--- a/source/exercises/unit_testing.rst
+++ b/source/exercises/unit_testing.rst
@@ -13,7 +13,6 @@ in the examples/Session06 dir, try::
 
 What we've just done here is the first step in what is called:
 
-.. rst-class:: centered
 
   **Test Driven Development**.
 
@@ -42,7 +41,6 @@ Copy both of these files into your home directory in the repo.
 
 Develop ``cigar_party.py`` until all the tests pass.
 
-.. rst-class:: left
 
   Pick an example from codingbat:
 

--- a/source/modules/BasicPython.rst
+++ b/source/modules/BasicPython.rst
@@ -14,7 +14,6 @@ Values
 
 All of programming is really about manipulating values.
 
-.. rst-class:: build
 
 * Values are pieces of unnamed data: ``42``, ``'Hello, world'``
 
@@ -28,7 +27,6 @@ All of programming is really about manipulating values.
 
 .. ifslides::
 
-    .. rst-class:: centered
 
         [demo]
 
@@ -189,7 +187,6 @@ But they are not:
 
 .. nextslide::
 
-.. rst-class:: center large
 
 Make sure your editor is set to use spaces only --
 
@@ -203,7 +200,6 @@ Expressions
 
 An *expression* is made up of values and operators.
 
-.. rst-class:: build
 
 * An expression is evaluated to produce a new value:  ``2 + 2``
 
@@ -222,7 +218,6 @@ An *expression* is made up of values and operators.
 
 .. ifslides::
 
-    .. rst-class:: centered
 
         [demo]
 
@@ -232,7 +227,6 @@ Symbols
 
 Symbols are how we give names to values (objects).
 
-.. rst-class:: build
 
 * Symbols must begin with an underscore or letter.
 * Symbols can contain any number of underscores, letters and numbers.
@@ -309,7 +303,6 @@ Evaluating the name will return the value to which it is bound
 Variables?
 ----------
 
-.. rst-class:: build
 
 * In most languages, what Python calls symbols or names are called "variables".
 
@@ -737,7 +730,6 @@ Exceptions are how Python tells you that something has gone wrong.
 
 There are several exceptions that you are likely to see a lot of:
 
-.. rst-class:: build
 
 * ``NameError``: indicates that you have tried to use a symbol that is not bound to a value.
 

--- a/source/modules/BasicPython.rst
+++ b/source/modules/BasicPython.rst
@@ -73,7 +73,6 @@ Expressions:
     In [5]: 3 + 4
     Out[5]: 7
 
-.. nextslide::
 
 Statements:
 statements carry out an action, but do not evaluate to a value, that is you can't assign to them (or put them in a lamda, or...)
@@ -87,7 +86,6 @@ statements carry out an action, but do not evaluate to a value, that is you can'
     In [8]: return something
 
 
-.. nextslide:: The Print Function
 
 It is somewhat obvious, but handy when playing with code:
 
@@ -104,7 +102,6 @@ You can print multiple things:
     the value is 5
 
 
-.. nextslide::
 
 Any Python object can be printed (though it might not be pretty...)
 
@@ -118,7 +115,6 @@ Any Python object can be printed (though it might not be pretty...)
     <class '__main__.bar'>
 
 
-.. nextslide:: Code Blocks
 
 Blocks of code are delimited by a colon and indentation:
 
@@ -140,7 +136,6 @@ Blocks of code are delimited by a colon and indentation:
     except:
         fix_the_problem()
 
-.. nextslide::
 
 Python uses indentation to delineate structure. This means that in Python, whitespace is **significant** (but **ONLY** for newlines and indentation).
 
@@ -153,7 +148,6 @@ The standard is to indent with **4 spaces**.
 Python requires spaces for indents. You can probably set your editor to replace tabs with spaces.
 This is a good idea as it is easier to type one tab than 4 spaces.
 
-.. nextslide::
 
 These two blocks look the same:
 
@@ -168,7 +162,6 @@ These two blocks look the same:
         print(i**2)
 
 
-.. nextslide::
 
 But they are not:
 
@@ -185,7 +178,6 @@ But they are not:
 **ALWAYS INDENT WITH 4 SPACES**
 
 
-.. nextslide::
 
 
 Make sure your editor is set to use spaces only --
@@ -415,7 +407,6 @@ You can't actually directly delete values in Python...
 
     NameError: name 'a' is not defined
 
-.. nextslide::
 
 The object is still there...Python will only delete it if there are no
 references to it.
@@ -767,7 +758,6 @@ The minimal function has at least one statement.
     def a_name():
         a_statement
 
-.. nextslide::
 
 Pass Statement does nothing (Note the indentation!)
 
@@ -899,7 +889,6 @@ This is actually the simplest possible function:
     def fun():
         return None
 
-.. nextslide::
 
 If you don't explicitly put ``return``  there, Python will return ``None``:
 

--- a/source/modules/Class_introduction.rst
+++ b/source/modules/Class_introduction.rst
@@ -11,7 +11,6 @@ In which you are introduced to this class, your instructors, your environment an
     :align: center
     :width: 38%
 
-.. rst-class:: credit
 
 `xkcd.com/353`_
 
@@ -25,7 +24,6 @@ Who are we?
 Who are you?
 ------------
 
-.. rst-class:: center medium
 
   Tell us a tiny bit about yourself:
 
@@ -38,7 +36,6 @@ Who are you?
 Introduction to This Class
 ==========================
 
-.. rst-class:: center large
 
   Introduction to Python
 

--- a/source/modules/Closures.rst
+++ b/source/modules/Closures.rst
@@ -26,7 +26,6 @@ but I even have trouble following that.
 
 So let's go straight to an example:
 
-.. nextslide::
 
 .. code-block:: python
 
@@ -45,7 +44,6 @@ Then defined a function, ``incr`` that adds one to the value in the list, and re
 
 [ Quiz: why is it: ``count = [start_at]``, rather than just ``count=start_at`` ]
 
-.. nextslide::
 
 So what type of object do you get when you call ``counter()``?
 
@@ -70,7 +68,6 @@ Being a function, we can, of course, call it:
 
 Each time is it called, it increments the value by one.
 
-.. nextslide::
 
 But what happens if we call ``counter()`` multiple times?
 

--- a/source/modules/ContextManagers.rst
+++ b/source/modules/ContextManagers.rst
@@ -44,7 +44,6 @@ You can write more robust code for handling your resources:
 But what exceptions do you want to catch?  And do you really want to have to
 remember to type all that **every** time you open a resource?
 
-.. nextslide:: It Gets Better
 
 Starting in version 2.5, Python provides a structure for reducing the
 repetition needed to handle resources like this.
@@ -76,7 +75,6 @@ when the code block ends.
 
 .. _pep343: http://legacy.python.org/dev/peps/pep-0343/
 
-.. nextslide:: A Growing Trend
 
 At this point in Python history, many functions you might expect to behave this
 way do:
@@ -158,7 +156,6 @@ Consider this code:
 ``Examples/Session10/context_managers.py``
 
 
-.. nextslide::
 
 This class doesn't do much of anything, but playing with it can help
 clarify the order in which things happen:
@@ -177,7 +174,6 @@ clarify the order in which things happen:
 
     Because the exit method returns True, the raised error is 'handled'.
 
-.. nextslide::
 
 What if we try with ``False``?
 
@@ -223,7 +219,6 @@ Consider this code:
         finally:
             print("__exit__ cleanup goes here")
 
-.. nextslide::
 
 The code is similar to the class defined previously.
 
@@ -241,7 +236,6 @@ And using it has similar results.  We can handle errors:
     errors handled here
     __exit__ cleanup goes here
 
-.. nextslide::
 
 Or, we can allow them to propagate:
 

--- a/source/modules/ContextManagers.rst
+++ b/source/modules/ContextManagers.rst
@@ -3,7 +3,6 @@ Context Managers
 
 **Repetition in code stinks (DRY!)**
 
-.. rst-class:: left build
 .. container::
 
 
@@ -50,7 +49,6 @@ remember to type all that **every** time you open a resource?
 Starting in version 2.5, Python provides a structure for reducing the
 repetition needed to handle resources like this.
 
-.. rst-class:: centered
 
 **Context Managers**
 
@@ -175,7 +173,6 @@ clarify the order in which things happen:
     This is in the context
     __exit__(<type 'exceptions.RuntimeError'>, this is the error message, <traceback object at 0x1049cca28>)
 
-.. rst-class:: build
 .. container::
 
     Because the exit method returns True, the raised error is 'handled'.

--- a/source/modules/Decorators.rst
+++ b/source/modules/Decorators.rst
@@ -61,7 +61,6 @@ one:
             print("\tResult --> {}".format(result))
             return result
 
-.. nextslide::
 
 That's not particularly nice, especially if you have lots of functions
 in your module.
@@ -84,7 +83,6 @@ Now imagine we defined the following, more generic *decorator*:
 
 (demo)
 
-.. nextslide::
 
 We could then make logging versions of our module functions:
 
@@ -109,7 +107,6 @@ Then, where we want to see the results, we can use the logged version:
 
     It'd be nicer if we could just call the old function and have it log.
 
-.. nextslide::
 
 Remembering that you can easily rebind symbols in Python using *assignment
 statements* leads you to this form:
@@ -203,7 +200,6 @@ function with given arguments:
             self.memoized[args] = self.function(*args)
             return self.memoized[args]
 
-.. nextslide::
 
 Let's try that out with a potentially expensive function:
 
@@ -241,7 +237,6 @@ decorator in order, from bottom to top:
         pass
     func = decorator_two(decorator_one(func))
 
-.. nextslide::
 
 Let's define another decorator that will time how long a given call takes:
 
@@ -257,7 +252,6 @@ Let's define another decorator that will time how long a given call takes:
             return result
         return timed
 
-.. nextslide::
 
 And now we can use this new decorator stacked along with our memoizing
 decorator:
@@ -284,7 +278,6 @@ for you to be writing your own.
 
 We've seen a few already:
 
-.. nextslide::
 
 For example, ``@staticmethod`` and ``@classmethod`` can also be used as simple
 callables, without the nifty decorator expression:
@@ -310,7 +303,6 @@ Note that the "``def``" binds the name ``add``, then the next line
 rebinds it.
 
 
-.. nextslide::
 
 The ``classmethod()`` builtin can do the same thing:
 
@@ -353,7 +345,6 @@ Two weeks ago we saw this code:
         def x(self):
             del self._x
 
-.. nextslide::
 
 But this could also be accomplished like so:
 
@@ -375,7 +366,6 @@ But this could also be accomplished like so:
 ``Examples/Session10/property_ugly.py``
 
 
-.. nextslide::
 
 Note that in this case, the decorator object returned by the property decorator
 itself implements additional decorators as attributes on the returned method

--- a/source/modules/Decorators.rst
+++ b/source/modules/Decorators.rst
@@ -3,7 +3,6 @@ Decorators
 
 **A Short Reminder**
 
-.. rst-class:: left
 
     Functions are things that generate values based on input (arguments).
 
@@ -29,11 +28,9 @@ A Definition
 There are many things you can do with a simple pattern like this one.
 So many, that we give it a special name:
 
-.. rst-class:: centered medium
 
 **Decorator**
 
-.. rst-class:: build centered
 
     "A decorator is a function that takes a function as an argument and
     returns a function as a return value."
@@ -51,7 +48,6 @@ one:
     def add(a, b):
         return a + b
 
-.. rst-class:: build
 .. container::
 
     You want to see when each function is called, with what arguments and
@@ -106,7 +102,6 @@ Then, where we want to see the results, we can use the logged version:
          Result --> 7
     Out[37]: 7
 
-.. rst-class:: build
 .. container::
 
     This is nice, but we have to call the new function wherever we originally
@@ -128,7 +123,6 @@ statements* leads you to this form:
         return a + b
     add = logged_func(add)
 
-.. rst-class:: build
 .. container::
 
     And now you can simply use the code you've already written and calls to
@@ -181,7 +175,6 @@ or a class that implements the ``__call__`` special method.
 
 So in fact the definition should be updated as follows:
 
-.. rst-class:: centered medium
 
 A decorator is a callable that takes a callable as an argument and
 returns a callable as a return value.

--- a/source/modules/DictsAndSets.rst
+++ b/source/modules/DictsAndSets.rst
@@ -507,7 +507,6 @@ Set Methods
       File "<stdin>", line 1, in <module>
     KeyError: 2
 
-.. nextslide::
 
 All the "set" operations from math class...
 

--- a/source/modules/EnvironmentOverview.rst
+++ b/source/modules/EnvironmentOverview.rst
@@ -72,7 +72,6 @@ Try it out:
     one string plus another
     >>>
 
-.. nextslide:: Tools in the Interpreter
 
 When you are in an interpreter, there are a number of tools available to
 you.
@@ -93,7 +92,6 @@ There is a help system:
 
 You can type ``q`` to exit the help viewer.
 
-.. nextslide:: Tools in the Interpreter
 
 You can also use the ``dir`` builtin to find out about the attributes of a
 given object:
@@ -113,7 +111,6 @@ given object:
 
 This allows you quite a bit of latitude in exploring what Python is.
 
-.. nextslide:: Advanced Interpreters
 
 In addition to the built-in interpreter, there are several more advanced
 interpreters available to you.
@@ -133,7 +130,6 @@ fashion.
 
 This is where an Editor fits in.
 
-.. nextslide:: Text Editors Only
 
 Any good text editor will do.
 
@@ -148,7 +144,6 @@ You need a real "programmers text editor"
 A text editor saves only what it shows you, with no special formatting
 characters hidden behind the scenes.
 
-.. nextslide:: Minimum Requirements
 
 At a minimum, your editor should have:
 

--- a/source/modules/EnvironmentOverview.rst
+++ b/source/modules/EnvironmentOverview.rst
@@ -3,9 +3,7 @@ Introduction to the Environment
 
 There are three basic elements to your environment when working with Python:
 
-.. rst-class:: left
 
-.. rst-class:: build
 
 * The Command Line
 * The Interpreter
@@ -154,14 +152,12 @@ characters hidden behind the scenes.
 
 At a minimum, your editor should have:
 
-.. rst-class:: build
 
 * Syntax Colorization
 * Automatic Indentation
 
 In addition, great features to add include:
 
-.. rst-class:: build
 
 * Tab completion
 * Code linting

--- a/source/modules/Files.rst
+++ b/source/modules/Files.rst
@@ -348,7 +348,6 @@ All data in all files is binary -- that's how computers work. So in Python3, "te
 
 But this too is complicated -- there are multiple ways that binary data can be mapped to Unicode text, known as "encodings". In Python, text files are by default opened with the "utf-8" encoding. These days, that mostly "just works".
 
-.. nextslide::
 
 But if you read a binary file as text, then Python will try to interpret the bytes as utf-8 encoded text -- and this will likely fail:
 
@@ -369,7 +368,6 @@ But if you read a binary file as text, then Python will try to interpret the byt
 
     UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
 
-.. nextslide::
 
 In Python2, it's less likely that you'll get an error like this -- it doesn't try to decode the file as it's read -- even for text files -- so it's a bit tricky and more error prone.
 

--- a/source/modules/Git.rst
+++ b/source/modules/Git.rst
@@ -80,7 +80,6 @@ Working with Remotes
 
 With git, you work with *local* repositories and the *remotes* that they are connected to.
 
-.. rst-class:: build
 .. container::
 
    Git uses shortcuts to address *remotes*. Cloned repositories get an *origin* shortcut for free:
@@ -95,7 +94,6 @@ With git, you work with *local* repositories and the *remotes* that they are con
    the UWPCE-PythonCert GitHub account (it shows up twice, because there is
    a shortcut for both fetch from and push to this remote).
 
-.. rst-class:: build
 .. container::
 
     You can work on any project you wish to that has a public repository on GitHub. However, since you won't have permission to edit most projects directly, there is such a thing as *forking* a project.
@@ -152,7 +150,6 @@ original repository, so that you can get changes made by other contributors befo
 You can add *remotes* at will, to connect your *local* repository or to other
 copies of it in different remote locations.
 
-.. rst-class:: build
 .. container::
 
     This allows you to grab changes made to the repository in these other

--- a/source/modules/GitWorkflow.rst
+++ b/source/modules/GitWorkflow.rst
@@ -46,7 +46,6 @@ students/marie_curie/mailroom
 
 Regardless of what you are working on, first make sure you don't have anything in your repository that you forgot to commit:
 
-.. rst-class:: build
 .. container::
 
     .. code-block:: bash
@@ -102,7 +101,6 @@ Now you can do your coding. For this example, that is simply adding a readme.
 
 Once you are done coding, always a good idea to look at what you have done.
 
-.. rst-class:: build
 .. container::
 
     Check the status

--- a/source/modules/IPythonIntroduction.rst
+++ b/source/modules/IPythonIntroduction.rst
@@ -43,7 +43,6 @@ Start it up
     (live demo)
 
 
-.. nextslide:: IPython basics
 
 This is the stuff I use every day:
 
@@ -65,7 +64,6 @@ This is the stuff I use every day:
   - ``%paste`` (this keeps whitespace cleaner for you)
 
 
-.. nextslide:: IPython basics (cont)
 
 * getting help:
 

--- a/source/modules/Iteration.rst
+++ b/source/modules/Iteration.rst
@@ -295,7 +295,6 @@ You can do that in a for loop, also:
 Looping through two iterables at once:
 --------------------------------------
 
-.. rst-class:: mlarge
 
   ``zip``
 
@@ -322,7 +321,6 @@ There can be more than two:
 Need the index and the item?
 ----------------------------
 
-.. rst-class:: mlarge
 
   ``enumerate``
 

--- a/source/modules/IteratorsAndGenerators.rst
+++ b/source/modules/IteratorsAndGenerators.rst
@@ -251,7 +251,6 @@ Generator functions "yield" a value, rather than returning a value.
 State is preserved in between yields.
 
 
-.. nextslide:: generator functions
 
 A function with ``yield``  in it is a "factory" for a generator
 
@@ -266,7 +265,6 @@ Each instance keeps its own state.
 
 Really just a shorthand for an iterator class that does the book keeping for you.
 
-.. nextslide::
 
 An example: like ``range()``
 
@@ -283,7 +281,6 @@ Real World Example from FloatCanvas:
 https://github.com/svn2github/wxPython/blob/master/3rdParty/FloatCanvas/floatcanvas/FloatCanvas.py#L100
 
 
-.. nextslide::
 
 Note:
 

--- a/source/modules/IteratorsAndGenerators.rst
+++ b/source/modules/IteratorsAndGenerators.rst
@@ -2,12 +2,10 @@ Iterators and Generators
 =========================
 
 
-.. rst-class:: large centered
 
   The Tools of Pythonicity
 
 
-.. rst-class:: medium
 
     What goes on in those for loops?
 

--- a/source/modules/Modules.rst
+++ b/source/modules/Modules.rst
@@ -53,7 +53,6 @@ An indent *could* be:
 
 If you want anyone to take you seriously as a Python developer:
 
-.. rst-class:: centered
 
 **Always use four spaces -- really!**
 
@@ -145,7 +144,6 @@ import \* ?
 
     from modulename import *
 
-.. rst-class:: centered large
 
 **Don't do this!**
 
@@ -184,7 +182,6 @@ In addition to importing modules, you can run them.
 
 There are a few ways to do this:
 
-.. rst-class:: build
 
 * ``$ python hello.py``   -- must be in current working directory
 * ``$ python -m hello``   -- any module on PYTHONPATH anywhere on the system

--- a/source/modules/MoreOnMutability.rst
+++ b/source/modules/MoreOnMutability.rst
@@ -29,7 +29,6 @@ one way to make a copy of a list:
 
 they are different lists.
 
-.. nextslide::
 
 What if we set an element to a new value?
 
@@ -45,7 +44,6 @@ What if we set an element to a new value?
 
 So they are independent.
 
-.. nextslide::
 
 But what if we mutate an element?
 
@@ -61,7 +59,6 @@ But what if we mutate an element?
 
 uuh oh! mutating an element in one list mutated the one in the other list.
 
-.. nextslide::
 
 Why is that?
 
@@ -97,7 +94,6 @@ but if not, you can use the ``copy`` module to make a copy:
 
 This is also a shallow copy.
 
-.. nextslide::
 
 But there is another option:
 
@@ -118,7 +114,6 @@ But there is another option:
 
 ``deepcopy`` recurses through the object, making copies of everything as it goes.
 
-.. nextslide::
 
 
 I happened on this thread on stack overflow:

--- a/source/modules/Packaging.rst
+++ b/source/modules/Packaging.rst
@@ -121,7 +121,6 @@ Installing Packages
 * ``pip`` should find appropriate binary wheels if they are there.
 
 
-.. nextslide::
 
 In the beginning, there was the ``distutils``:
 
@@ -186,7 +185,6 @@ Dependencies:
 
   * Particularly on Windows
 
-.. nextslide::
 
 **Linux**
 
@@ -207,7 +205,6 @@ Pretty straightforward:
 (may need "something-devel" packages)
 
 
-.. nextslide::
 
 **Windows**
 
@@ -228,7 +225,6 @@ MS now has a compiler just for python!
 
 http://www.microsoft.com/en-us/download/details.aspx?id=44266
 
-.. nextslide::
 
 **OS-X**
 
@@ -241,7 +237,6 @@ Lots of Python versions:
 
 Binary Installers (dmg or wheel) have to match python version
 
-.. nextslide::
 
 **OS-X**
 

--- a/source/modules/Packaging.rst
+++ b/source/modules/Packaging.rst
@@ -102,7 +102,6 @@ http://pypi.python.org/pypi
 
 Installing Packages
 -------------------
-.. rst-class:: medium
 
     **From source**
 
@@ -110,7 +109,6 @@ Installing Packages
 
 * With the system installer (apt-get, yum, etc...)
 
-.. rst-class:: medium
 
     **From binaries:**
 

--- a/source/modules/Properties.rst
+++ b/source/modules/Properties.rst
@@ -37,7 +37,6 @@ But what if you need to add behavior later?
 * check data validity
 * keep things in sync
 
-.. nextslide::
 
 .. code-block:: ipython
 

--- a/source/modules/Properties.rst
+++ b/source/modules/Properties.rst
@@ -9,7 +9,6 @@ https://en.wikipedia.org/wiki/Property_%28programming%29#Python
 Attributes are clear and concise
 --------------------------------
 
-.. rst-class:: left
 .. container::
 
     One of the strengths of Python is lack of clutter.
@@ -33,7 +32,6 @@ Getter and Setters
 
 But what if you need to add behavior later?
 
-.. rst-class:: build
 
 * do some calculation
 * check data validity

--- a/source/modules/Recursion.rst
+++ b/source/modules/Recursion.rst
@@ -12,7 +12,6 @@ With recursion, if you are not careful, this stack can get *very* deep.
 Python has a maximum limit to how much it can recurse. This is intended to
 save your machine from running out of RAM.
 
-.. nextslide:: Recursion can be Useful
 
 Recursion is especially useful for a particular set of problems.
 

--- a/source/modules/Sequences.rst
+++ b/source/modules/Sequences.rst
@@ -6,7 +6,6 @@
 Python Sequences
 ################
 
-.. rst-class:: center large
 
 Ordered collections of objects
 
@@ -460,7 +459,6 @@ There are some complexities about that -- but more on that in another lesson.
 Lists, Tuples...
 ================
 
-.. rst-class:: center large
 
 The *primary* sequence types.
 
@@ -644,7 +642,6 @@ Look familiar from lists??
 Lists vs. Tuples
 ----------------
 
-.. rst-class:: center large
 
     So why have both?
 
@@ -656,7 +653,6 @@ Mutability
    :width: 35%
    :alt: Presto change-o
 
-.. rst-class:: credit
 
 image from flickr by `illuminaut`_, (CC by-nc-sa)
 

--- a/source/modules/Sequences.rst
+++ b/source/modules/Sequences.rst
@@ -279,7 +279,6 @@ All sequences support the ``in`` and ``not in`` membership operators:
     In [18]: 42 not in s
     Out[18]: True
 
-.. nextslide:: Membership in Strings
 
 For strings, the membership operations are like ``substring`` operations in
 other languages:
@@ -704,7 +703,6 @@ Try this out:
     Out[31]: ['spam', 'raspberries', 'ham']
 
 
-.. nextslide:: Tuples are not
 
 We repeat the exercise with a Tuple:
 
@@ -937,7 +935,6 @@ Shrinking the List
     In [208]: food
     Out[208]: ['eggs']
 
-.. nextslide:: Removing Chunks of a List
 
 You can also delete *slices* of a list with the ``del`` keyword:
 

--- a/source/modules/SpecialMethodsAndProtocols.rst
+++ b/source/modules/SpecialMethodsAndProtocols.rst
@@ -316,7 +316,6 @@ And then we can call it:
 
     result = my_fun(some_arguments)
 
-.. nextslide::
 
 But what if we need to store some data to know how to evaluate that function?
 

--- a/source/modules/StaticAndClassMethods.rst
+++ b/source/modules/StaticAndClassMethods.rst
@@ -43,7 +43,6 @@ A *static method* is a method that doesn't get self:
 .. [demo: :download:`static_method.py <../../Examples/Session08/static_method.py>`]
 
 
-.. nextslide:: Why?
 
 .. container::
 
@@ -131,7 +130,6 @@ keys:
     TypeError: cannot convert dictionary update sequence element #0 to a sequence
 
 
-.. nextslide:: ``dict.fromkeys()``
 
 The stock constructor for a dictionary won't work this way. So the dict object
 implements an alternate constructor that *can*.
@@ -152,7 +150,6 @@ implements an alternate constructor that *can*.
 
 See also datetime.datetime.now(), etc....
 
-.. nextslide:: Curious?
 
 Properties, Static Methods and Class Methods are powerful features of Python's
 OO model.

--- a/source/modules/StaticAndClassMethods.rst
+++ b/source/modules/StaticAndClassMethods.rst
@@ -6,7 +6,6 @@ Static and Class Methods
 ########################
 
 
-.. rst-class:: left build
 .. container::
 
     You've seen how methods of a class are *bound* to an instance when it is
@@ -20,7 +19,6 @@ Static and Class Methods
 
     |
 
-    .. rst-class:: centered
 
     **But what if you don't want or need an instance?**
 
@@ -41,14 +39,12 @@ A *static method* is a method that doesn't get self:
     In [37]: StaticAdder.add(3, 6)
     Out[37]: 9
 
-.. rst-class:: centered
 
 .. [demo: :download:`static_method.py <../../Examples/Session08/static_method.py>`]
 
 
 .. nextslide:: Why?
 
-.. rst-class:: build
 .. container::
 
     Where are static methods useful?
@@ -90,7 +86,6 @@ argument
     in a class method:  <class '__main__.Classy'>
     Out[42]: 16
 
-.. rst-class:: centered
 
 .. [demo: :download:`class_method.py <../../Examples/Session08/class_method.py>`]
 
@@ -98,7 +93,6 @@ argument
 Why?
 ----
 
-.. rst-class:: build
 .. container::
 
     Unlike static methods, class methods are quite common.

--- a/source/quizzes/comprehensions_quiz.rst
+++ b/source/quizzes/comprehensions_quiz.rst
@@ -8,11 +8,9 @@ Playing with Comprehensions
 ============================
 
 
-.. rst-class:: large left
 
     Goal:
 
-.. rst-class:: medium left
 
     Getting Familiar with list, set and dict comprehensions
 

--- a/source/quizzes/comprehensions_quiz.rst
+++ b/source/quizzes/comprehensions_quiz.rst
@@ -204,7 +204,6 @@ First a slightly bigger, more interesting (or at least bigger..) dict:
                   "salad": "greek",
                   "pasta": "lasagna"}
 
-.. nextslide:: Working with this dict:
 
 1. Print the dict by passing it to a string format method, so that you
 get something like:
@@ -223,7 +222,6 @@ keys but with the number of 'a's in each value. You can do this either
 by editing the dict in place, or making a new one. If you edit in place,
 make a copy first!
 
-.. nextslide::
 
 5. Create sets s2, s3 and s4 that contain numbers from zero through twenty,
 divisible 2, 3 and 4.

--- a/source/references/packaging.rst
+++ b/source/references/packaging.rst
@@ -119,7 +119,6 @@ Installing Packages
 * ``pip`` should find appropriate binary wheels if they are there.
 
 
-.. nextslide::
 
 In the beginning, there was the ``distutils``:
 
@@ -184,7 +183,6 @@ Dependencies:
 
   * Particularly on Windows
 
-.. nextslide::
 
 **Linux**
 
@@ -205,7 +203,6 @@ Pretty straightforward:
 (may need "something-devel" packages)
 
 
-.. nextslide::
 
 **Windows**
 
@@ -226,7 +223,6 @@ MS now has a compiler just for python!
 
 http://www.microsoft.com/en-us/download/details.aspx?id=44266
 
-.. nextslide::
 
 **OS-X**
 
@@ -239,7 +235,6 @@ Lots of Python versions:
 
 Binary Installers (dmg or wheel) have to match python version
 
-.. nextslide::
 
 **OS-X**
 

--- a/source/references/packaging.rst
+++ b/source/references/packaging.rst
@@ -100,7 +100,6 @@ http://pypi.python.org/pypi
 
 Installing Packages
 -------------------
-.. rst-class:: medium
 
     **From source**
 
@@ -108,7 +107,6 @@ Installing Packages
 
 * With the system installer (apt-get, yum, etc...)
 
-.. rst-class:: medium
 
     **From binaries:**
 

--- a/source/supplemental/dev_environment/git_overview.rst
+++ b/source/supplemental/dev_environment/git_overview.rst
@@ -49,7 +49,6 @@ A Picture of git
     :width: 80%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     A git repository is a set of points in time, with history showing where
@@ -69,7 +68,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     Each point in time can also have a label that points to it.
@@ -83,7 +81,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     You may also be familiar with the label "master".
@@ -99,7 +96,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     When you make a *commit* in git, you add a new point to the timeline.
@@ -119,7 +115,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     You can make a new *branch* with the ``branch`` command.
@@ -134,7 +129,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     You can use the ``checkout`` command to switch to the new branch.
@@ -153,7 +147,6 @@ A Picture of git
     :width: 75%
     :class: center
 
-.. rst-class:: build
 .. container::
 
     While it is checked out, new commits move the *session01* label.
@@ -164,7 +157,6 @@ A Picture of git
 
 You can use this to switch between branches and make changes in isolation.
 
-.. rst-class:: build
 .. container::
 
     .. figure:: /_static/git_checkout_master.png
@@ -177,7 +169,6 @@ You can use this to switch between branches and make changes in isolation.
 
 .. nextslide:: Merging Branches
 
-.. rst-class:: build
 .. container::
 
     Branching allows you to keep related sets of work separate from each-other.
@@ -200,7 +191,6 @@ You can use this to switch between branches and make changes in isolation.
 The ``merge`` command allows you to *combine* your work on one branch with the
 work on another.
 
-.. rst-class:: build
 .. container::
 
     It creates a new commit which reconciles the differences:
@@ -214,7 +204,6 @@ work on another.
 
 .. nextslide:: Conflicts
 
-.. rst-class:: build
 .. container::
 
     Sometimes when you ``merge`` two branches, you get *conflicts*.

--- a/source/supplemental/dev_environment/git_overview.rst
+++ b/source/supplemental/dev_environment/git_overview.rst
@@ -62,7 +62,6 @@ A Picture of git
     The path from one point to the previous is represented by the *difference*
     between the two points.
 
-.. nextslide::
 
 .. figure:: /_static/git_head.png
     :width: 75%
@@ -75,7 +74,6 @@ A Picture of git
     One of these is *HEAD*, which always points to the place in the timeline
     that you are currently looking at.
 
-.. nextslide::
 
 .. figure:: /_static/git_master_branch.png
     :width: 75%
@@ -90,7 +88,6 @@ A Picture of git
 
     A *branch* is actually just a label for a certain set of points in time.
 
-.. nextslide::
 
 .. figure:: /_static/git_new_commit.png
     :width: 75%
@@ -109,7 +106,6 @@ A Picture of git
     The noun "commit" is a particular state of the repository -- it has been saved and has particular name (hash) -- it is one if the points on that timeline.
 
 
-.. nextslide:: Making a Branch
 
 .. figure:: /_static/git_new_branch.png
     :width: 75%
@@ -123,7 +119,6 @@ A Picture of git
 
     Notice that it *does not* check out that branch -- you will still be working in the current branch.
 
-.. nextslide:: Making a Branch
 
 .. figure:: /_static/git_checkout_branch.png
     :width: 75%
@@ -141,7 +136,6 @@ A Picture of git
           master
         * session01
 
-.. nextslide:: Making a Branch
 
 .. figure:: /_static/git_commit_on_branch.png
     :width: 75%
@@ -153,7 +147,6 @@ A Picture of git
 
     Notice that HEAD is *always* the same as "where you are now"
 
-.. nextslide:: Making a Branch
 
 You can use this to switch between branches and make changes in isolation.
 
@@ -167,7 +160,6 @@ You can use this to switch between branches and make changes in isolation.
         :width: 75%
         :class: center
 
-.. nextslide:: Merging Branches
 
 .. container::
 
@@ -186,7 +178,6 @@ You can use this to switch between branches and make changes in isolation.
 
     The final step in the process is merging your work.
 
-.. nextslide:: Merging Branches
 
 The ``merge`` command allows you to *combine* your work on one branch with the
 work on another.
@@ -202,7 +193,6 @@ work on another.
     Notice that this commit has **two** parents.
 
 
-.. nextslide:: Conflicts
 
 .. container::
 
@@ -223,7 +213,6 @@ work on another.
         * ========= (the pivot point between two branches' content)
         * >>>>>>>>> *hash2* (stuff from the branch being merged)
 
-.. nextslide:: Conflicts
 
 Your job in fixing a conflict is to decide exactly what to keep.
 

--- a/source/supplemental/installing/python_for_mac.rst
+++ b/source/supplemental/installing/python_for_mac.rst
@@ -8,17 +8,14 @@ Setting up OS-X for Python
 Getting The Tools
 ==================
 
-.. rst-class:: left
 
 OS-X comes with Python out of the box, but not the full setup you'll need for development or this class. It also doesn't have the latest version(s), and no version of Python 3.
 
 So we recommend installing a new version.
 
-.. rst-class:: left
 
 **Note**:
 
-.. rst-class:: left
 
 If you use ``macports`` or ``homebrew`` to manage \*nix software on your machine, feel free to use those for ``python``, ``git``, etc, as well. But make sure you have Python 3.6.*
 


### PR DESCRIPTION
I favored a conservative approach to avoid damage (I hope!). I included the command I used below in case it needs further work:

from the source directory:

step 1 discover and validate
grep -r 'nextslide::' *
grep -r '\.\. rst-' *

step two delete associated rows
grep -Rl "nextslide::" . | xargs sed -i "/nextslide::/d"
find . -type f -exec sed -i '/\.\. rst-/d' {} +