### PR TITLE
Updates removing demo

### DIFF
--- a/source/modules/BasicPython.rst
+++ b/source/modules/BasicPython.rst
@@ -25,11 +25,6 @@ All of programming is really about manipulating values.
 
   - Try ``type(42)`` - the type of a value determines what it can do.
 
-.. ifslides::
-
-
-        [demo]
-
 
 Literals for the Basic Value types:
 ------------------------------------
@@ -207,11 +202,6 @@ An *expression* is made up of values and operators.
   * This is the source of many errors, especially in handling text.
 
 * Type errors - checked at run time only.
-
-.. ifslides::
-
-
-        [demo]
 
 
 Symbols
@@ -473,8 +463,6 @@ object** using the ``is`` operator:
     In [76]: other_count is count
     Out[76]: False
 
-[demo]
-
 **NOTE:** Checking the id of an object, or using "is" to check if two objects are the same is rarely used except for debugging and understanding what's going on under the hood. They are not used regularly in production code.
 
 
@@ -499,7 +487,6 @@ You can test for the equality of certain values with the ``==`` operator
 
 A string is never equal to a number!
 
-[demo]
 
 Singletons
 ----------

--- a/source/modules/Decorators.rst
+++ b/source/modules/Decorators.rst
@@ -81,8 +81,6 @@ Now imagine we defined the following, more generic *decorator*:
             return result
         return logged
 
-(demo)
-
 
 We could then make logging versions of our module functions:
 
@@ -157,7 +155,6 @@ that wierd `@` symbol:
 The declarative form (called a decorator expression) is far more common,
 but both have the identical result, and can be used interchangeably.
 
-(demo)
 
 Callables
 ---------

--- a/source/modules/Git.rst
+++ b/source/modules/Git.rst
@@ -126,7 +126,7 @@ So, everyone will commit to this repository, and everyone will have access to ev
 
 This will make it easier to collaborate. Weirdly enough, collaborating is important for developing code, both for class and in the *real world*.
 
-We will do a live demo of setting up a machine for working with this repository now.
+We will do a walkthrough of setting up a machine for working with this repository now.
 
 The first thing we have to do is on the GitHub website. We will create a fork of the class repository from the ``UWPCE-PythonCert`` account on GitHub into your personal account. Please create a GitHub account if you don't have one already.
 
@@ -138,7 +138,7 @@ Note: You do not have to use your real name to set up your git account.
 
 Everyone should now have a copy of the class repository in their account on the GitHub website.
 
-The next step is to make a *clone* of your fork on your own computer, which means that **your fork** in GitHub is the *origin* (Demo):
+The next step is to make a *clone* of your fork on your own computer, which means that **your fork** in GitHub is the *origin*:
 
 .. figure:: /_static/remotes_clone.png
    :width: 50%

--- a/source/modules/IPythonIntroduction.rst
+++ b/source/modules/IPythonIntroduction.rst
@@ -15,9 +15,6 @@ Specifically, you'll want to pay attention to the information about
 .. _official documentation: http://ipython.org/ipython-doc/stable/index.html
 .. _Using IPython for Interactive Work: http://ipython.org/ipython-doc/stable/interactive/index.html
 
-.. ifslides::
-
-
 The very basics of IPython
 --------------------------
 
@@ -37,11 +34,6 @@ Start it up
   %quickref -> Quick reference.
   help      -> Python's own help system.
   object?   -> Details about 'object', use 'object??' for extra details.
-
-.. ifslides::
-
-    (live demo)
-
 
 
 This is the stuff I use every day:

--- a/source/modules/IteratorsAndGenerators.rst
+++ b/source/modules/IteratorsAndGenerators.rst
@@ -46,8 +46,6 @@ To make an object iterable, you simply have to implement the __getitem__ method.
             raise IndexError
         return position
 
-Demo
-
 
 ``iter()``
 -----------

--- a/source/modules/Modules.rst
+++ b/source/modules/Modules.rst
@@ -119,8 +119,6 @@ There are a few ways to import modules:
     import modulename as a_new_name
     from modulename import this as that
 
-    (demo)
-
 
 Importing from packages
 -----------------------
@@ -130,8 +128,6 @@ Importing from packages
     import packagename.modulename
     from packagename.modulename import this, that
     from package import modulename
-
-    (demo)
 
 Here's a nice reference:
 
@@ -171,8 +167,6 @@ It must be explicitly reloaded to be re-run
 
     import importlib
     importlib.reload(modulename)
-
-    (demo)
 
 
 Running a Module
@@ -215,9 +209,6 @@ You can put code here that lets your module be a utility *script*
 You can put code here that demonstrates the functions contained in your module
 
 You can put code here that proves that your module works.
-
-
-[demo]
 
 
 Import Interactions

--- a/source/references/packaging.rst
+++ b/source/references/packaging.rst
@@ -35,7 +35,6 @@ Modules and Packages
     for p in sys.path:
         print p
 
-(demo)
 
 Installing Python
 -----------------

--- a/source/scripts/python_overview.rst
+++ b/source/scripts/python_overview.rst
@@ -61,9 +61,9 @@ Dynamic typing means that type checking and dispatch happen at run-time
 
 For example, for a really simple line of code like:
 
-[code demo]
+.. code-block:: ipython
 
-x = a + b
+    x = a + b
 
 
 The interpreter, when the code is running, goes through a process somethign like this:
@@ -81,7 +81,7 @@ values in Python are Strongly typed.
 
 At any given moment, a particular python value will have one and only one type. And that type can be checked at run time.
 
-[code demo]
+.. code-block:: ipython
 
     In [1]: a = 5
 
@@ -101,13 +101,14 @@ And the type of the value thing determines what it can do.
 
 Watch what happens when I try to add a and b above:
 
-[code demo]
 
-In [5]: a + b
----------------------------------------------------------------------------
-TypeError                                 Traceback (most recent call last)
-<ipython-input-5-f96fb8f649b6> in <module>()
-----> 1 a + b
+.. code-block:: ipython
+
+    In [5]: a + b
+    ---------------------------------------------------------------------------
+    TypeError                                 Traceback (most recent call last)
+    <ipython-input-5-f96fb8f649b6> in <module>()
+    ----> 1 a + b
 
 TypeError: unsupported operand type(s) for +: 'int' and 'str'
 


### PR DESCRIPTION
This was messy and required manual intervention. Here's a log of what I did. I also created a new issue for pre-Jan 8:
DELETED "demo" ::: modules/Git.rst:We will do a live demo of setting up a machine for working with this repository now.
DELETED "demo" ::: modules/Git.rst:The next step is to make a *clone* of your fork on your own computer, which means that **your fork** in GitHub is the *origin* (Demo):
DELETED all occurences ::: modules/BasicPython.rst:        [demo]
DELETED all occurences ::: modules/Decorators.rst:(demo)
DELETED all occurences ::: modules/Modules.rst:[demo]
DELETED all occurences ::: modules/IPythonIntroduction.rst:    (live demo)
DELETED all occurences ::: references/packaging.rst:(demo)
CHANGED ALL demo text into .. code-block:: ipython ::: scripts/python_overview.rst:[code demo]
DONT THINK THIS FILE IS NEEDED ::: scripts/dynamic_string_formatting.rst:demo here...
