### PR TITLE
Add Windows command for activating virtualenv

### DIFF
--- a/source/supplemental/dev_environment/virtualenv.rst
+++ b/source/supplemental/dev_environment/virtualenv.rst
@@ -133,6 +133,10 @@ using the ``source`` command:
     (demoenv)$ which python
     /Users/cewing/demoenv/bin/python
 
+On Windows, the *activate* script is in the ``Scripts`` folder:
+
+``> \path\to\env\Scripts\activate``
+
 There.  That's better. Now whenever you run the ``python`` command, the
 executable that will be used will be the new one in your ``demoenv``.
 


### PR DESCRIPTION
One of our students in the self-paced online course noticed that the Windows command for activating virtualenv was missing from the course materials.