### PR TITLE
Update sum_series() comment to avoid unexpected confusion

### DIFF
--- a/source/exercises/series_template.py
+++ b/source/exercises/series_template.py
@@ -21,10 +21,11 @@ def sum_series(n, n0=0, n1=1):
 
     :param n0=0: value of zeroth element in the series
     :param n1=1: value of first element in the series
-
-    if n0 == 0 and n1 == 1, the result is the Fibbonacci series
-
-    if n0 == 2 and n1 == 1, the result is the Lucas series
+    
+    This function should generalize the fibonacci() and the lucas(),
+    so that this function works for any first two numbers for a sum series.
+    Once generalized that way, sum_series(n, 0, 1) should be equivalent to fibonacci(n).
+    And sum_series(n, 2, 1) should be equivalent to lucas(n).
     """
     pass
 


### PR DESCRIPTION
The original comment caused confusion to a lot of students in my class, so proposing this rewrite. See an example of such confusion like [this](https://github.com/UWPCE-PythonCert-ClassRepos/Au2018-Py210B/blob/master/students/shawn_degraw/session02/series.py#L18-L49).