### PR TITLE
Try Travis CI/CD (automate build_gh_pages.sh)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: trusty
+
+language: python
+
+python: "3.6"
+
+cache: pip
+
+install: "pip install -r requirements.txt"
+
+script:
+  - make html
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  local-dir: build/html
+  on:
+    branch: master
+  target-branch: gh-pages


### PR DESCRIPTION
This is to automate the HTML building (`build_gh_pages.sh` can be retired with this).

See [this](https://travis-ci.org/hosungs/PythonCertDevel) for a Travis CI/CD build result on my fork.

See [this](https://hosungs.github.io/PythonCertDevel/) for the automatically deployed result.

See [this commit](https://github.com/hosungs/PythonCertDevel/commit/3eaa2e030a70f3e58b653ee259215077ae862df7) that was auto-committed by the Travis CI/CD job.

To enable CI/CD on UWPCE-PythonCert/PythonCertDevel, an admin (which I'm not) needs to sign up at https://travis-ci.org/, enable the repo for CI, generate a personal access token (`public_repo` scope only), set the environment variable `GITHUB_TOKEN` with the generated personal access token at the Travis CI job settings page, and merge this PR.

I'd be happy to do that if I'm given the admin right.

Thanks,
Hosung